### PR TITLE
fix: Add --no-ssl-verify flag and other refinements

### DIFF
--- a/nice-tts/src/nice_tts/llm.py
+++ b/nice-tts/src/nice_tts/llm.py
@@ -5,6 +5,25 @@ from openai import OpenAI
 from dotenv import load_dotenv, find_dotenv
 from datetime import datetime
 import tiktoken
+import ssl
+import typer
+
+def _disable_ssl_verify():
+    """
+    Disables SSL verification via monkey-patching.
+    This is a workaround for issues in some corporate environments with proxies.
+    """
+    try:
+        _create_unverified_https_context = ssl._create_unverified_context
+    except AttributeError:
+        # Fallback for environments where this is not available
+        pass
+    else:
+        ssl._create_default_https_context = _create_unverified_https_context
+    typer.secho(
+        "Warning: SSL verification has been disabled. This is not recommended.",
+        fg=typer.colors.YELLOW,
+    )
 
 def load_llm_config():
     """
@@ -84,10 +103,13 @@ def _split_text_into_chunks(text: str, max_tokens: int, model: str) -> list[str]
 
     return chunks
 
-def refine_transcript(txt_path: str, output_fine_path: str) -> str:
+def refine_transcript(txt_path: str, output_fine_path: str, no_ssl_verify: bool = False) -> str:
     """
     Refines a transcript from a TXT file using an LLM and saves it to a specified path.
     """
+    if no_ssl_verify:
+        _disable_ssl_verify()
+
     p_txt_path = Path(txt_path)
     if not p_txt_path.is_file():
         raise FileNotFoundError(f"TXT file not found at: {txt_path}")
@@ -141,11 +163,14 @@ def refine_transcript(txt_path: str, output_fine_path: str) -> str:
     return output_fine_path
 
 def summarize_transcript(
-    refined_text_path: str, original_audio_path: str, output_md_path: str
+    refined_text_path: str, original_audio_path: str, output_md_path: str, no_ssl_verify: bool = False
 ) -> str:
     """
     Generates a Chinese meeting summary and saves it to a specified path.
     """
+    if no_ssl_verify:
+        _disable_ssl_verify()
+
     p_refined_text_path = Path(refined_text_path)
     p_original_audio_path = Path(original_audio_path)
     if not p_refined_text_path.is_file():

--- a/nice-tts/src/nice_tts/main.py
+++ b/nice-tts/src/nice_tts/main.py
@@ -53,6 +53,11 @@ def process(
         "-f",
         help="Force re-processing of all steps.",
     ),
+    no_ssl_verify: bool = typer.Option(
+        False,
+        "--no-ssl-verify",
+        help="Disable SSL verification for downloading tokenizer data. Use with caution.",
+    ),
 ):
     """
     Process a single audio file or all audio files in a directory.
@@ -101,7 +106,11 @@ def process(
                 continue
             try:
                 typer.secho("Step 2: Refining transcript...", fg=typer.colors.BLUE)
-                llm.refine_transcript(txt_path=str(txt_path), output_fine_path=str(refined_path))
+                llm.refine_transcript(
+                    txt_path=str(txt_path),
+                    output_fine_path=str(refined_path),
+                    no_ssl_verify=no_ssl_verify,
+                )
                 typer.secho(f"✔ Refinement successful: {refined_path}", fg=typer.colors.GREEN)
             except Exception as e:
                 typer.secho(f"Error during refinement: {e}", fg=typer.colors.RED, err=True)
@@ -119,6 +128,7 @@ def process(
                     refined_text_path=str(refined_path),
                     original_audio_path=str(audio_file),
                     output_md_path=str(summary_path),
+                    no_ssl_verify=no_ssl_verify,
                 )
                 typer.secho(f"✔ Summarization successful: {summary_path}", fg=typer.colors.GREEN)
             except Exception as e:


### PR DESCRIPTION
This commit introduces a `--no-ssl-verify` flag to the `process` command to work around SSL verification issues that can occur in some network environments when downloading tokenizer data.

It also includes the previous changes to switch the whisper output to `.txt` and to implement token-based chunking for LLM interactions.